### PR TITLE
fix reading property of a triple

### DIFF
--- a/lib/jsonld-serializer.js
+++ b/lib/jsonld-serializer.js
@@ -58,7 +58,7 @@ var JsonLdSerializer = function (rdf, options) {
 
     graph.forEach(function (t) {
       var s = subjectIndex(t.subject);
-      var p = t.predicate.valueOf();
+      var p = t.property.valueOf();
 
       if (p == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type') {
         if (typeof jsonGraph[s]['@type'] === 'undefined') {


### PR DESCRIPTION
previously t.predicate is undefined and gives an error when serialising a graph to json-ld